### PR TITLE
Fix print display issues

### DIFF
--- a/apps/exam/static/index.html
+++ b/apps/exam/static/index.html
@@ -24,6 +24,25 @@
         .blockquote {
             border-left: gray 5px solid;
         }
+
+        /* In case of emergency, users may use Print => Save as PDF */
+        @media print {
+            /* Fix printing on Firefox, which only prints 1 page if display != block */
+            .exam > .row {
+                display: block;
+            }
+            /* Bootstrap seems to render the blue checkbox/radio backgrounds by filling in
+            label::before, and backgrounds sometimes don't show in economy print mode. This tells
+            the browser to use background colors for relevant form elements */
+            form .btn {
+                -webkit-print-color-adjust: exact; /* Chrome, Safari */
+                color-adjust: exact;               /* Firefox */
+            }
+            form .custom-control {
+                -webkit-print-color-adjust: exact;
+                color-adjust: exact;
+            }
+        }
     </style>
 
 </head>


### PR DESCRIPTION
We've told students to use `Print => Save as PDF` if something goes _really_ wrong. These fixes make the PDF actually usable. This took way too long to figure out. Browsers suck.

- Fix: checkboxes, radios, and buttons show up as blank/white/close-to-white, since Bootstrap colors these using background-color and modern browsers sometimes "optimize out" backgrounds.
- Fix: Firefox doesn't print all of `display: flex`, only the first page, leaving entire pages of questions out of the print.

Tested vaguely on:
- Safari 13.0.3
- Firefox 77.0a1 (2020-05-14)
- Chrome 81.0.4044.138